### PR TITLE
Fixed dangerous syntax error

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -86,7 +86,7 @@ def authenticate(**credentials):
             credentials=_clean_credentials(credentials))
 
 
-ef login(request, user):
+def login(request, user):
     """
     Persist a user id and a backend in the request. This way a user doesn't
     have to reauthenticate on every request. Note that data set during


### PR DESCRIPTION
Corrected a [simple typo in the (./django/contrib/auth/__init__.py) login method](https://github.com/shuttl-io/django/blob/master/django/contrib/auth/__init__.py).